### PR TITLE
bug: fix no-default-export&parser version

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/umijs/umi-fabric#readme",
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "^1.4.2",
-    "@typescript-eslint/parser": "^1.4.2",
+    "@typescript-eslint/parser": "canary",
     "eslint": "^5.16.0",
     "eslint-config-airbnb": "^17.1.0",
     "eslint-config-airbnb-base": "^13.1.0",

--- a/src/eslint.ts
+++ b/src/eslint.ts
@@ -49,7 +49,7 @@ module.exports = {
     // Too restrictive, writing ugly code to defend against a very unlikely scenario: https://eslint.org/docs/rules/no-prototype-builtins
     "no-prototype-builtins": "off",
     "import/prefer-default-export": "off",
-    "import/no-default-export": [true, "camel-case"],
+    "import/no-default-export": [0, "camel-case"],
     // Too restrictive: https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/destructuring-assignment.md
     "react/destructuring-assignment": "off",
     "react/jsx-filename-extension": "off",


### PR DESCRIPTION
1. import/no-default-export
![image](https://user-images.githubusercontent.com/32446924/59974311-49348300-95dd-11e9-9f9e-c29cdd07c333.png)

2. @typescript-eslint/parser
![image](https://user-images.githubusercontent.com/32446924/59974326-69644200-95dd-11e9-8697-fc12cb02f685.png)

resolve: https://github.com/typescript-eslint/typescript-eslint/issues/641